### PR TITLE
Improve the way the NIF is loaded as dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ endif
 
 LDFLAGS += $(shell pkg-config --cflags --libs librsvg-2.0)
 
-all: priv/rsvg.so
+all: $(MIX_APP_PATH)/priv/rsvg.so
 
-priv/rsvg.so: c_src/rsvg.c
-	mkdir -p ./priv
+$(MIX_APP_PATH)/priv/rsvg.so: c_src/rsvg.c
+	mkdir -p $(MIX_APP_PATH)/priv
 	$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $@ c_src/rsvg.c
 
 clean:
-	rm -r priv/rsvg.so*
+	rm -r $(MIX_APP_PATH)/priv/rsvg.so*
 
 .PHONY: clean

--- a/lib/rsvg.ex
+++ b/lib/rsvg.ex
@@ -1,7 +1,7 @@
 defmodule RSVG do
   @on_load :load_nifs
 
-  def load_nifs, do: :erlang.load_nif(:code.priv_dir(:rsvg) ++ '/rsvg', 0)
+  def load_nifs, do: :erlang.load_nif(:filename.join(:code.priv_dir('rsvg'), 'rsvg'), 0)
 
   @spec render(svg :: binary, format :: :png) :: binary
   def render(svg, :png) do

--- a/lib/rsvg.ex
+++ b/lib/rsvg.ex
@@ -4,9 +4,12 @@ defmodule RSVG do
   def load_nifs, do: :erlang.load_nif(:filename.join(:code.priv_dir('rsvg'), 'rsvg'), 0)
 
   @spec render(svg :: binary, format :: :png) :: binary
-  def render(svg, :png) do
+  def render(svg, :png),  do: render(svg, :png, {347, 126})
+
+  @spec render(svg :: binary, format :: :png, {w :: non_neg_integer(), h :: non_neg_integer()}) :: binary
+  def render(svg, :png, {w, h}) do
     # TODO: Extract dimensions from svg
-    nif_render_png(svg, 347, 126)
+    nif_render_png(svg, w, h)
   end
 
   def nif_render_png(_svg, _width, _height), do: raise("NIF nif_render_png/3 not implemented")

--- a/mix.exs
+++ b/mix.exs
@@ -1,15 +1,3 @@
-defmodule Mix.Tasks.Compile.Make do
-  def run(_args) do
-    {result, code} = System.cmd("make", [], stderr_to_stdout: true)
-    IO.binwrite(result)
-
-    case code do
-      0 -> :ok
-      code -> {:error, ["Exit code: #{code}"]}
-    end
-  end
-end
-
 defmodule RSVG.MixProject do
   use Mix.Project
 
@@ -18,7 +6,7 @@ defmodule RSVG.MixProject do
       app: :rsvg,
       version: "0.1.0",
       elixir: "~> 1.14",
-      compilers: [:make] ++ Mix.compilers(),
+      compilers: [:elixir_make] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -30,7 +18,8 @@ defmodule RSVG.MixProject do
 
   defp deps do
     [
-      {:mix_test_watch, "~> 1.0", only: [:dev, :test], runtime: false}
+      {:mix_test_watch, "~> 1.0", only: [:dev, :test], runtime: false},
+      {:elixir_make, "~> 0.7.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "elixir_make": {:hex, :elixir_make, "0.7.1", "314f2a5450254db0446ba94cc1ba12a25b83b457f24aa9cc21c128cead5d03aa", [:mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: true]}], "hexpm", "0f1ad4787b4d7489563351cbf85c9221a852f5441364a2cb3ffd36f2fda7f7fb"},
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "mix_test_watch": {:hex, :mix_test_watch, "1.1.0", "330bb91c8ed271fe408c42d07e0773340a7938d8a0d281d57a14243eae9dc8c3", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm", "52b6b1c476cbb70fd899ca5394506482f12e5f6b0d6acff9df95c7f1e0812ec3"},
 }


### PR DESCRIPTION
Using elixir_make the problems with using `Mix.install` in `iex` were gone